### PR TITLE
produce force-open binding for recover

### DIFF
--- a/background.nim
+++ b/background.nim
@@ -79,7 +79,10 @@ macro background*(call: typed): untyped =
   let c = nskVar.genSym"continuation"  # the continuation we'll send off
   monitor.body =
     genAstOpt({}, worker = bindSym"worker", noop = bindSym"noop",
-              c, mCall, Arg = ident"Backgrounded"):
+              c, mCall, Arg = ident"Backgrounded",
+              # Use force-open binding to make sure that the recover() of
+              # the generated continuation is bound
+              recover = bindSym("recover", brForceOpen)):
       var c = whelp mCall                 # call the runner continuation
       var th: Thread[Arg]                 # prepare a Thread[Backgrounded]
       createThread(th, worker, c)         # pass the continuation to the thread


### PR DESCRIPTION
Without this binding, the `recover` bound in monitor will favor the
default `recover` implementation in CPS instead of the one generated
for the continuation